### PR TITLE
Fixes unnecessary line break

### DIFF
--- a/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
+++ b/library/src/main/java/com/addisonelliott/segmentedbutton/SegmentedButton.java
@@ -518,6 +518,10 @@ public class SegmentedButton extends View
         if (textWidth < 0)
             return;
 
+        // textPaint.getTypeface() is selectedTextTypeface
+        if (textPaint.getTypeface() != textTypeface)
+            textPaint.setTypeface(textTypeface);
+
         // Create new static layout with width
         // Old way of creating static layout was deprecated but I dont think there is any speed difference between
         // the two


### PR DESCRIPTION
Fixes unnecessary line break after width of SegmentedButtonGroup is changed if textStyle is not bold and selectedTextStyle is bold.
Reset typeface of `textPaint` in `measureTextWidth` because it is possible that typeface of `textPaint` was set to `selectedTextStyle` in `onDraw`.